### PR TITLE
Remove Eve-Skillplan

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,7 +147,6 @@ While these fitting tools haven't been updated in some time they can still be us
 
 #### Skills
 
-* [EVE-Skillplan.net](https://www.eve-skillplan.net) - Web based and responsive skill planner to plan and share your training using your favourite devices - PC/Mac, tablet or smartphone.
 * [EveSkillboard](https://eveskillboard.com/) - Character Skill Sheet, Standings, Corporation History, Ships can/cannot fly.
 * [SkillQ](https://skillq.net) - A simple webapp for monitoring skill queues of various characters.
 


### PR DESCRIPTION
https://eve-skillplan.net redirects to a post on the eve forums by the developer announce the discontinuance of the site

https://forums.eveonline.com/t/eve-skillplan-net-plan-your-training-online-v2-2-9/17858/54?u=legedric_striker